### PR TITLE
Includes reviver parameter on JSON.parse redefinition

### DIFF
--- a/debug_toolbar/statics/js/refresh.js
+++ b/debug_toolbar/statics/js/refresh.js
@@ -9,8 +9,8 @@
     function deleteCookie(name) {
         document.cookie = `${name}=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
     }
-    JSON.parse = function(text) {
-        const data = parse(text);
+    JSON.parse = function(text, reviver) {
+        const data = parse(text, reviver);
         const cookie = getCookie("dtRefresh");
 
         if (!cookie) return data;


### PR DESCRIPTION
This solves [Issue #13](https://github.com/mongkok/fastapi-debug-toolbar/issues/13) that explains how the `reviver` parameter is excluded from the [JSON.parse](https://developer.mozilla.org/es/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse) redefinition. This causes errors when trying to decode parameters using the `openapi` module contained in the FastApi framework.