### PR TITLE
fix version home_page null

### DIFF
--- a/debug_toolbar/statics/js/versions.js
+++ b/debug_toolbar/statics/js/versions.js
@@ -41,7 +41,7 @@ function pypiIndex() {
         return {
             version: pypi.info.version,
             requires_python: pypi.info.requires_python,
-            home_page: pypi.info.home_page,
+            home_page: pypi.info.home_page || '',
             releases: Object.fromEntries(
                 Object.entries(pypi.releases).map(
                     function([k, v], i) {


### PR DESCRIPTION
fix https://pypi.org/pypi/idna/json having the property set as `null` and later using ".length on null" in [utils.js:82](https://github.com/AndreasMietk/fastapi-debug-toolbar/blob/main/debug_toolbar/statics/js/utils.js#L82)

partially closing https://github.com/mongkok/fastapi-debug-toolbar/issues/16