### PR TITLE
Add note to prevent compression errors

### DIFF
--- a/docs/src/quickstart.py
+++ b/docs/src/quickstart.py
@@ -2,4 +2,6 @@ from debug_toolbar.middleware import DebugToolbarMiddleware
 from fastapi import FastAPI
 
 app = FastAPI(debug=True)
+# This line must come before any compression middleware is added, e.g app.add_middleware(GZipMiddleware, minimum_size=500)
 app.add_middleware(DebugToolbarMiddleware)
+


### PR DESCRIPTION
Without this note, user will get error due to compression middleware compressing html before debug toolbar has been added to page.

`
500 Server Error
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte
 `

<img width="864" alt="image" src="https://user-images.githubusercontent.com/14875933/226064395-5b311981-3c17-4afb-aee3-0d63eb452c8f.png">
