### PR TITLE
Update sqlalchemy.py

### DIFF
--- a/debug_toolbar/panels/sqlalchemy.py
+++ b/debug_toolbar/panels/sqlalchemy.py
@@ -2,7 +2,7 @@ import typing as t
 from time import perf_counter
 
 from fastapi import Request, Response
-from fastapi.concurrency import AsyncExitStack
+from contextlib import AsyncExitStack
 from fastapi.dependencies.utils import solve_dependencies
 from sqlalchemy import event
 from sqlalchemy.engine import Connection, Engine, ExecutionContext

--- a/debug_toolbar/panels/sqlalchemy.py
+++ b/debug_toolbar/panels/sqlalchemy.py
@@ -2,7 +2,10 @@ import typing as t
 from time import perf_counter
 
 from fastapi import Request, Response
-from contextlib import AsyncExitStack
+try:
+    from fastapi.concurrency import AsyncExitStack
+except ImportError:
+    from contextlib import AsyncExitStack
 from fastapi.dependencies.utils import solve_dependencies
 from sqlalchemy import event
 from sqlalchemy.engine import Connection, Engine, ExecutionContext


### PR DESCRIPTION
Adding import from `contextlib` due to breakage with Fastapi V1.0.6 and onwards