### PR TITLE
Fix adding engines to `SQLAlchemyPanel` from `AsyncSession`

### DIFF
--- a/debug_toolbar/panels/sqlalchemy.py
+++ b/debug_toolbar/panels/sqlalchemy.py
@@ -42,7 +42,7 @@ class SQLAlchemyPanel(SQLPanel):
         self.add_query(str(context.engine.url), query)
 
     async def add_engines(self, request: Request):  # noqa: C901
-        def add_bind_to_engines(bind: Connection | Engine):
+        def add_bind_to_engines(bind: t.Union[Connection, Engine]):
             if isinstance(bind, Connection):
                 self.engines.add(bind.engine)
             else:

--- a/debug_toolbar/panels/sqlalchemy.py
+++ b/debug_toolbar/panels/sqlalchemy.py
@@ -41,7 +41,7 @@ class SQLAlchemyPanel(SQLPanel):
         }
         self.add_query(str(context.engine.url), query)
 
-    async def add_engines(self, request: Request):
+    async def add_engines(self, request: Request):  # noqa: C901
         def add_bind_to_engines(bind: Connection | Engine):
             if isinstance(bind, Connection):
                 self.engines.add(bind.engine)
@@ -63,9 +63,9 @@ class SQLAlchemyPanel(SQLPanel):
             else:
                 for value in solved_result[0].values():
                     if isinstance(value, AsyncSession):
-                        value = getattr(value, "sync_session")
+                        value = getattr(value, "sync_session", None)
                     if isinstance(value, Session):
-                        binds = getattr(value, "_Session__binds")
+                        binds = getattr(value, "_Session__binds", None)
                         if binds:
                             for bind in binds.values():
                                 add_bind_to_engines(bind)

--- a/debug_toolbar/panels/sqlalchemy.py
+++ b/debug_toolbar/panels/sqlalchemy.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException, Request, Response
 from fastapi.dependencies.utils import solve_dependencies
 from sqlalchemy import event
 from sqlalchemy.engine import Connection, Engine, ExecutionContext
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from debug_toolbar.panels.sql import SQLPanel
@@ -41,6 +42,12 @@ class SQLAlchemyPanel(SQLPanel):
         self.add_query(str(context.engine.url), query)
 
     async def add_engines(self, request: Request):
+        def add_bind_to_engines(bind: Connection | Engine):
+            if isinstance(bind, Connection):
+                self.engines.add(bind.engine)
+            else:
+                self.engines.add(bind)
+
         route = request["route"]
 
         if hasattr(route, "dependant"):
@@ -55,13 +62,16 @@ class SQLAlchemyPanel(SQLPanel):
                 pass
             else:
                 for value in solved_result[0].values():
+                    if isinstance(value, AsyncSession):
+                        value = getattr(value, "sync_session")
                     if isinstance(value, Session):
-                        bind = value.get_bind()
-
-                        if isinstance(bind, Connection):
-                            self.engines.add(bind.engine)
+                        binds = getattr(value, "_Session__binds")
+                        if binds:
+                            for bind in binds.values():
+                                add_bind_to_engines(bind)
                         else:
-                            self.engines.add(bind)
+                            bind = value.get_bind()
+                            add_bind_to_engines(bind)
 
     async def process_request(self, request: Request) -> Response:
         await self.add_engines(request)


### PR DESCRIPTION
Hi :з We use `AsyncSession` in our project and faced issues with `SQLAlchemyPanel` which does not support `AsyncSession`. 
Moreover, there is no support for a `Session` with multiple binds. 
In this PR, I have attempted to fix these issues.