### PR TITLE
Update dependencies.py - Fix an issue with adding the SQLAlchemy panel when using fastapi v0.114.1

### DIFF
--- a/debug_toolbar/dependencies.py
+++ b/debug_toolbar/dependencies.py
@@ -17,9 +17,10 @@ async def get_dependencies(request: Request) -> dict[str, t.Any] | None:
                 dependant=route.dependant,
                 dependency_overrides_provider=route.dependency_overrides_provider,
                 async_exit_stack=AsyncExitStack(),
+                embed_body_fields=False,
             )
         except HTTPException:
             pass
         else:
-            return solved_result[0]
+            return solved_result.values
     return None


### PR DESCRIPTION
Fix an issue with adding the SQLAlchemy panel when using fastapi v0.114.1

TypeError: solve_dependencies() missing 1 required keyword-only argument: 'embed_body_fields'
and 
TypeError: 'SolvedDependency' object is not subscriptable

Relates to issues:
https://github.com/mongkok/fastapi-debug-toolbar/issues/53
https://github.com/mongkok/fastapi-debug-toolbar/issues/54